### PR TITLE
Bind Widget instead of HTMLPanel

### DIFF
--- a/src/main/resources/com/arcbees/plugin/template/presenter/widget/__name__View.java.vm
+++ b/src/main/resources/com/arcbees/plugin/template/presenter/widget/__name__View.java.vm
@@ -9,12 +9,13 @@ package ${package};
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.gwtplatform.mvp.client.ViewImpl;
 import com.gwtplatform.mvp.client.ViewWithUiHandlers;
 
 public class ${name}View extends ${extends} implements ${name}Presenter.MyView {
-    public interface Binder extends UiBinder<HTMLPanel, ${name}View> {
+    public interface Binder extends UiBinder<Widget, ${name}View> {
     }
 
     @UiField


### PR DESCRIPTION
This fixes a very minor annoyance where if you change the root element in the view's ui:binder from HTMLPanel it causes an error that is only caught at compile.
